### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/agent/src/main/java/org/jfrog/teamcity/agent/util/PathHelper.java
+++ b/agent/src/main/java/org/jfrog/teamcity/agent/util/PathHelper.java
@@ -29,6 +29,8 @@ import java.util.Map;
  * @author Noam Y. Tenne
  */
 public abstract class PathHelper {
+    
+    private PathHelper() {}
 
     public static Map<String, String> getPublishedArtifactsPatternPairs(String publishedArtifactsPropertyValue) {
         Map<String, String> patternPairMap = Maps.newHashMap();

--- a/agent/src/main/java/org/jfrog/teamcity/agent/util/PathMatcher.java
+++ b/agent/src/main/java/org/jfrog/teamcity/agent/util/PathMatcher.java
@@ -28,6 +28,8 @@ import java.util.List;
  * @author Yossi Shaul
  */
 public abstract class PathMatcher {
+    
+    private PathMatcher() {}
 
     private static AntPathMatcher antPathMatcher = new AntPathMatcher();
     private static final List<String> DEFAULT_EXCLUDES = Lists.newArrayList(

--- a/agent/src/main/java/org/jfrog/teamcity/agent/util/RepositoryHelper.java
+++ b/agent/src/main/java/org/jfrog/teamcity/agent/util/RepositoryHelper.java
@@ -10,6 +10,8 @@ import java.util.Map;
  */
 public class RepositoryHelper {
 
+    private RepositoryHelper() {}
+    
     /**
      * Get job resolution repository from the view
      *

--- a/common/src/main/java/org/jfrog/teamcity/common/CustomDataStorageKeys.java
+++ b/common/src/main/java/org/jfrog/teamcity/common/CustomDataStorageKeys.java
@@ -4,6 +4,8 @@ package org.jfrog.teamcity.common;
  * @author Noam Y. Tenne
  */
 public class CustomDataStorageKeys {
+    
+    private CustomDataStorageKeys() {}
 
     //Key of the history for builds that have been run with build info activated
     public final static String RUN_HISTORY = "artifactoryPluginRunHistory";

--- a/common/src/main/java/org/jfrog/teamcity/common/ReleaseManagementParameterKeys.java
+++ b/common/src/main/java/org/jfrog/teamcity/common/ReleaseManagementParameterKeys.java
@@ -4,6 +4,8 @@ package org.jfrog.teamcity.common;
  * @author Noam Y. Tenne
  */
 public class ReleaseManagementParameterKeys {
+    
+    private ReleaseManagementParameterKeys() {}
 
     private final static String PREFIX = ConstantValues.PLUGIN_PREFIX + "releaseManagement.";
 

--- a/common/src/main/java/org/jfrog/teamcity/common/RunTypeUtils.java
+++ b/common/src/main/java/org/jfrog/teamcity/common/RunTypeUtils.java
@@ -6,6 +6,8 @@ import java.util.Map;
  * @author Noam Y. Tenne
  */
 public abstract class RunTypeUtils {
+    
+    private RunTypeUtils() {}
 
     public static final String ANT_RUNNER = "Ant";
     public static final String GRADLE_RUNNER = "gradle-runner";

--- a/common/src/main/java/org/jfrog/teamcity/common/RunnerParameterKeys.java
+++ b/common/src/main/java/org/jfrog/teamcity/common/RunnerParameterKeys.java
@@ -4,6 +4,8 @@ package org.jfrog.teamcity.common;
  * @author Noam Y. Tenne
  */
 public class RunnerParameterKeys {
+    
+    private RunnerParameterKeys() {}
 
     public final static String PREFIX = ConstantValues.PLUGIN_PREFIX + "selectedDeployableServer.";
     public final static String BLACKDUCK_PREFIX = PREFIX + "blackduck.";

--- a/common/src/main/java/org/jfrog/teamcity/common/TriggerParameterKeys.java
+++ b/common/src/main/java/org/jfrog/teamcity/common/TriggerParameterKeys.java
@@ -4,6 +4,8 @@ package org.jfrog.teamcity.common;
  * @author Noam Y. Tenne
  */
 public class TriggerParameterKeys {
+    
+    private TriggerParameterKeys() {}
 
     public final static String PREFIX = ConstantValues.PLUGIN_PREFIX + "selectedTriggerServer.";
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed