### PR TITLE
TCAP-250: Exchange exists for isFile check before checksum.

### DIFF
--- a/agent/src/main/java/org/jfrog/teamcity/agent/BaseBuildInfoExtractor.java
+++ b/agent/src/main/java/org/jfrog/teamcity/agent/BaseBuildInfoExtractor.java
@@ -271,7 +271,7 @@ public abstract class BaseBuildInfoExtractor<P> implements BuildInfoExtractor<P,
             mapToReturn = calculatedChecksumCache.get(artifactPath);
         } else {
             File artifactFile = new File(artifactPath);
-            if (artifactFile.exists()) {
+            if (artifactFile.isFile()) {
                 try {
                     Map<String, String> checksums =
                             FileChecksumCalculator.calculateChecksums(artifactFile, "sha1", "md5");


### PR DESCRIPTION
The change takes into account that the checksum method can only create a checksum for files and no directories.  This is related to the change in TCAP-250.